### PR TITLE
Fix typo of Isreal to Israel

### DIFF
--- a/map
+++ b/map
@@ -4758,7 +4758,7 @@
                         map.on('mousemove', 'israel-trail', function(e) {
                             map.setPaintProperty('israel-trail', 'line-width', 4);
             
-                            trailNamePopup.setText('Isreal Trail');
+                            trailNamePopup.setText('Israel Trail');
                             trailNamePopup
                                 .setLngLat(e.lngLat)
                                 .addTo(map);


### PR DESCRIPTION
The tooltip for the Israel Trail has the vowels switched.